### PR TITLE
Refactored card model, table, and related commands

### DIFF
--- a/app/Console/Commands/RebuildCardsTable.php
+++ b/app/Console/Commands/RebuildCardsTable.php
@@ -17,7 +17,7 @@ class RebuildCardsTable extends Command
     {
         ini_set('memory_limit', '1G');
         $this->info('Fetching Scryfall bulk data URL...');
-        $bulkDataUrl = 'https://api.scryfall.com/bulk-data/default-cards';
+        $bulkDataUrl = 'https://api.scryfall.com/bulk-data/oracle-cards';
         $response = Http::get($bulkDataUrl);
         
         if ($response->failed()) {
@@ -58,16 +58,14 @@ class RebuildCardsTable extends Command
                     ['id' => $card->id],
                     [
                         'name' => $card->name ?? null,
+                        'type_line' => $card->type_line ?? null,
+                        'oracle_text' => $card->oracle_text ?? null,
+                        'color_identity' => isset($card->color_identity) ? json_encode($card->color_identity) : '{}',
+                        'mana_cost' => $card->mana_cost ?? null,
+                        'power' => $card->power ?? null,
+                        'toughness' => $card->toughness ?? null,
                         'scryfall_uri' => $card->scryfall_uri ?? null,
-                        'highres_image' => $card->highres_image ?? false,
-                        'image_status' => $card->image_status ?? 'unknown',
                         'image_uris' => isset($card->image_uris) ? json_encode($card->image_uris) : '{}',
-                        'foil' => $card->foil ?? false,
-                        'nonfoil' => $card->nonfoil ?? false,
-                        'finishes' => isset($card->finishes) ? json_encode($card->finishes) : '[]',
-                        'set' => $card->set ?? 'unknown',
-                        'set_name' => $card->set_name ?? 'unknown',
-                        'collector_number' => $card->collector_number ?? '0',
                         ]
                     );
                     $processed++;

--- a/app/Console/Commands/ShowCards.php
+++ b/app/Console/Commands/ShowCards.php
@@ -15,13 +15,16 @@ class ShowCards extends Command
         $cards = DB::table('cards')->take(10)->get();
 
         $this->info("Displaying the first 10 cards:");
-        $this->table(['Scryfall ID', 'Name', 'Set', 'Collector Number', 'Scryfall URI'], $cards->map(function ($card) {
+        $this->table(['id', 'name', 'type line', 'color identity','mana cost','power','toughness', 'oracle text'], $cards->map(function ($card) {
             return [
                 $card->id,
                 $card->name,
-                $card->set,
-                $card->collector_number,
-                $card->scryfall_uri,
+                $card->type_line,
+                $card->color_identity,
+                $card->mana_cost,
+                $card->power,
+                $card->toughness,
+                $card->oracle_text,
             ];
         })->toArray());
     }

--- a/app/Models/Card.php
+++ b/app/Models/Card.php
@@ -13,19 +13,17 @@ class Card extends Model
         'id',
         'name',
         'scryfall_uri',
-        'highres_image',
-        'image_status',
         'image_uris',
-        'foil',
-        'nonfoil',
-        'finishes',
-        'set',
-        'set_name',
-        'collector_number',
+        'type_line',
+        'oracle_text',
+        'color_identity',
+        'mana_cost',
+        'power',
+        'toughness',
     ];
 
     protected $casts = [
         'image_uris' => 'array',
-        'finishes' => 'array',
+        'color_identity' => 'array',
     ];
 }

--- a/database/migrations/2024_12_31_011054_update_cards_table_structure.php
+++ b/database/migrations/2024_12_31_011054_update_cards_table_structure.php
@@ -1,0 +1,69 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('cards', function (Blueprint $table) {
+            // Drop old columns that are no longer needed
+            $table->dropColumn([
+                'highres_image',
+                'image_status',
+                'foil',
+                'nonfoil',
+                'finishes',
+                'set',
+                'set_name',
+                'collector_number',
+            ]);
+
+            // Add new columns based on the new data structure
+            $table->string('type_line')->nullable();
+            $table->text('oracle_text')->nullable();
+            $table->json('color_identity')->nullable(); // Store color identity as JSON
+            $table->string('mana_cost')->nullable();
+            $table->string('power')->nullable();
+            $table->string('toughness')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('cards', function (Blueprint $table) {
+            // Add back the columns that were removed
+            $table->boolean('highres_image')->nullable();
+            $table->string('image_status')->nullable();
+            $table->boolean('foil')->nullable();
+            $table->boolean('nonfoil')->nullable();
+            $table->json('finishes')->nullable();
+            $table->string('set')->nullable();
+            $table->string('set_name')->nullable();
+            $table->string('collector_number')->nullable();
+
+            // Drop the new columns
+            $table->dropColumn([
+                'type_line',
+                'oracle_text',
+                'color_identity',
+                'mana_cost',
+                'power',
+                'toughness',
+            ]);
+        });
+    }
+};
+


### PR DESCRIPTION
Activity:

- scryfall fetch command
  - swapped bulk scryfall json imports from general to oracle card sets
  - reconfigured property mapping to support frontend development, not included double sided cards
- modelling and migration
  - updated card model and migration to account for dropping properties and creating new properties
- show cards command
  -  realigned the property references to make the command functional