### PR TITLE
Button Shelf component

### DIFF
--- a/resources/js/Components/ButtonShelf.tsx
+++ b/resources/js/Components/ButtonShelf.tsx
@@ -55,7 +55,7 @@ const ButtonShelf = ({ buttons }: ButtonShelfProps) => {
         <>
             <div ref={buttonShelfRef} className="bookmark h-[1px] w-full"></div>
             <div
-                className={`buttonShelfWrapper duration-350 flex w-full justify-center transition-transform ${fixShelf ? 'fixed -top-[100px] left-0 translate-y-[100px] bg-black py-4' : 'relative'} z-50 my-4`}
+                className={`buttonShelfWrapper duration-350 flex w-full justify-center transition-transform ${fixShelf ? 'fixed -top-[100px] left-0 translate-y-[100px] bg-black py-4' : 'relative'} z-50`}
             >
                 <div className={`container grid ${gridColsClass} gap-1`}>
                     {buttons.map((button, index) => (

--- a/resources/js/Components/ButtonShelf.tsx
+++ b/resources/js/Components/ButtonShelf.tsx
@@ -82,30 +82,6 @@ const ButtonShelf = ({ buttons }: ButtonShelfProps) => {
                         </>
                     ))}
                 </div>
-                {/* <div className="container flex flex-wrap gap-1">
-                    {buttons.map((button, index) => (
-                        <button
-                            key={`${index}-${button.label}`}
-                            className="max-w-[25%] flex-grow basis-1/4 rounded bg-blue-500 px-4 py-2 font-bold text-white hover:bg-blue-700"
-                            aria-label={button.label}
-                            onClick={button.action}
-                        >
-                            {button.label}
-                        </button>
-                    ))}
-                </div> */}
-                {/* <div className="container flex flex-wrap gap-1">
-                    {buttons.map((button, index) => (
-                        <button
-                            key={`${index}-${button.label}`}
-                            className="max-w-[calc(25%-0.25rem)] flex-grow basis-[calc(25%-0.25rem)] rounded bg-blue-500 px-4 py-2 font-bold text-white hover:bg-blue-700"
-                            aria-label={button.label}
-                            onClick={button.action}
-                        >
-                            {button.label}
-                        </button>
-                    ))}
-                </div> */}
             </div>
         </>
     );

--- a/resources/js/Components/ButtonShelf.tsx
+++ b/resources/js/Components/ButtonShelf.tsx
@@ -1,0 +1,114 @@
+import { useEffect, useRef, useState } from 'react';
+import { debounce } from '../utility';
+
+type Button = {
+    label: string;
+    action?: () => void;
+    link?: string;
+};
+
+type ButtonShelfProps = {
+    buttons: Button[];
+};
+
+const ButtonShelf = ({ buttons }: ButtonShelfProps) => {
+    const [fixShelf, setFixShelf] = useState(false);
+    const buttonShelfRef = useRef<HTMLDivElement>(null);
+
+    const handleScrollPast = (isIntersecting: boolean) => {
+        setFixShelf(!isIntersecting);
+    };
+
+    const debouncedHandleScrollPast = debounce(handleScrollPast, 100);
+
+    useEffect(() => {
+        const observer = new IntersectionObserver(
+            ([entry]) => {
+                debouncedHandleScrollPast(entry.isIntersecting);
+            },
+            {
+                root: null, // Use the viewport as the root
+                threshold: 0, // Trigger when the element is fully out of view
+            },
+        );
+
+        if (buttonShelfRef.current) {
+            observer.observe(buttonShelfRef.current);
+        }
+
+        return () => {
+            if (buttonShelfRef.current) {
+                observer.unobserve(buttonShelfRef.current);
+            }
+        };
+    }, [debouncedHandleScrollPast]);
+
+    if (!buttons.length) {
+        return null;
+    }
+
+    // Determine the number of columns based on the number of buttons
+    const gridColsClass =
+        buttons.length <= 4 ? `grid-cols-${buttons.length}` : 'grid-cols-4';
+
+    return (
+        <>
+            <div ref={buttonShelfRef} className="bookmark h-[1px] w-full"></div>
+            <div
+                className={`buttonShelfWrapper duration-350 flex w-full justify-center transition-transform ${fixShelf ? 'fixed -top-[100px] left-0 translate-y-[100px]' : 'relative'} z-50 mb-4`}
+            >
+                <div className={`container grid ${gridColsClass} gap-1`}>
+                    {buttons.map((button, index) => (
+                        <>
+                            {button.link ? (
+                                <a
+                                    key={`${index}-${button.label}`}
+                                    href={button.link}
+                                    className={`col-span-2 rounded bg-blue-500 px-4 py-2 text-center font-bold text-white hover:bg-blue-700 md:col-span-1`}
+                                    aria-label={button.label}
+                                >
+                                    {button.label}
+                                </a>
+                            ) : (
+                                <button
+                                    key={`${index}-${button.label}`}
+                                    className={`col-span-2 rounded bg-blue-500 px-4 py-2 font-bold text-white hover:bg-blue-700 md:col-span-1`}
+                                    aria-label={button.label}
+                                    onClick={button.action}
+                                >
+                                    {button.label}
+                                </button>
+                            )}
+                        </>
+                    ))}
+                </div>
+                {/* <div className="container flex flex-wrap gap-1">
+                    {buttons.map((button, index) => (
+                        <button
+                            key={`${index}-${button.label}`}
+                            className="max-w-[25%] flex-grow basis-1/4 rounded bg-blue-500 px-4 py-2 font-bold text-white hover:bg-blue-700"
+                            aria-label={button.label}
+                            onClick={button.action}
+                        >
+                            {button.label}
+                        </button>
+                    ))}
+                </div> */}
+                {/* <div className="container flex flex-wrap gap-1">
+                    {buttons.map((button, index) => (
+                        <button
+                            key={`${index}-${button.label}`}
+                            className="max-w-[calc(25%-0.25rem)] flex-grow basis-[calc(25%-0.25rem)] rounded bg-blue-500 px-4 py-2 font-bold text-white hover:bg-blue-700"
+                            aria-label={button.label}
+                            onClick={button.action}
+                        >
+                            {button.label}
+                        </button>
+                    ))}
+                </div> */}
+            </div>
+        </>
+    );
+};
+
+export default ButtonShelf;

--- a/resources/js/Components/ButtonShelf.tsx
+++ b/resources/js/Components/ButtonShelf.tsx
@@ -55,7 +55,7 @@ const ButtonShelf = ({ buttons }: ButtonShelfProps) => {
         <>
             <div ref={buttonShelfRef} className="bookmark h-[1px] w-full"></div>
             <div
-                className={`buttonShelfWrapper duration-350 flex w-full justify-center transition-transform ${fixShelf ? 'fixed -top-[100px] left-0 translate-y-[100px]' : 'relative'} z-50 mb-4`}
+                className={`buttonShelfWrapper duration-350 flex w-full justify-center transition-transform ${fixShelf ? 'fixed -top-[100px] left-0 translate-y-[100px] bg-black py-4' : 'relative'} z-50 my-4`}
             >
                 <div className={`container grid ${gridColsClass} gap-1`}>
                     {buttons.map((button, index) => (

--- a/resources/js/Pages/Cards/Index.tsx
+++ b/resources/js/Pages/Cards/Index.tsx
@@ -6,7 +6,6 @@ import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
 import { CardDataType } from '@/types/mtg';
 import { parseCardData } from '@/utility';
 import { Head } from '@inertiajs/react';
-import { useState } from 'react';
 
 export default function Cards({
     cards,

--- a/resources/js/Pages/Cards/Index.tsx
+++ b/resources/js/Pages/Cards/Index.tsx
@@ -31,7 +31,9 @@ export default function Cards({
         <AuthenticatedLayout header={<PageTitle>Shared Card Pool</PageTitle>}>
             <Head title="Card Pool" />
             <div className="container mx-auto px-3 py-4">
+                <div className="my-4">
                 <ButtonShelf buttons={buttons} />
+                </div>
                 <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
                     {parsedCards.length > 1 &&
                         parsedCards.map((card: CardDataType) => (

--- a/resources/js/Pages/Cards/Index.tsx
+++ b/resources/js/Pages/Cards/Index.tsx
@@ -1,9 +1,12 @@
+import ButtonShelf from '@/Components/ButtonShelf';
 import MTGCard from '@/Components/MTGCard';
 import PageTitle from '@/Components/PageTitle';
+
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
 import { CardDataType } from '@/types/mtg';
 import { parseCardData } from '@/utility';
 import { Head } from '@inertiajs/react';
+import { useState } from 'react';
 
 export default function Cards({
     cards,
@@ -15,10 +18,21 @@ export default function Cards({
     const parsedCards: CardDataType[] | [] = parseCardData(cards) || [];
     console.log('parsedCards', parsedCards);
     console.log('decks', decks);
+
+    const addCard = () => {
+        console.log('add a card');
+    };
+
+    const buttons = [
+        { label: 'Create a deck', link: '/decks/' },
+        { label: 'Add a Card', action: addCard },
+    ];
+
     return (
         <AuthenticatedLayout header={<PageTitle>Shared Card Pool</PageTitle>}>
             <Head title="Card Pool" />
             <div className="container mx-auto px-3 py-4">
+                <ButtonShelf buttons={buttons} />
                 <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
                     {parsedCards.length > 1 &&
                         parsedCards.map((card: CardDataType) => (

--- a/resources/js/Pages/Dashboard.tsx
+++ b/resources/js/Pages/Dashboard.tsx
@@ -34,24 +34,28 @@ export default function Dashboard({ cards }: { cards: { data: any } }) {
                     parentSetter={handleSearchResults}
                 />
                 <div className="-mx-3 flex flex-wrap">
-                    <div className="w-1/2 px-3 pb-3">
-                        <button
-                            className="btn w-full"
-                            onClick={() => setShowModal(true)}
-                        >
-                            Import a list
-                        </button>
-                    </div>
-                    <div className="w-1/2 px-3 pb-3">
-                        <button className="btn w-full">Create a list</button>
-                    </div>
-                    <div className="w-1/2 px-3 pb-3">
-                        <button className="btn w-full">Edit a list</button>
-                    </div>
-                    <div className="w-1/2 px-3 pb-3">
-                        <button className="btn w-full">
-                            View my shared cards
-                        </button>
+                    <div className="button-shelf w-full px-3 pb-3">
+                        <div className="w-1/2 px-3 pb-3">
+                            <button
+                                className="btn w-full"
+                                onClick={() => setShowModal(true)}
+                            >
+                                Import a list
+                            </button>
+                        </div>
+                        <div className="w-1/2 px-3 pb-3">
+                            <button className="btn w-full">
+                                Create a list
+                            </button>
+                        </div>
+                        <div className="w-1/2 px-3 pb-3">
+                            <button className="btn w-full">Edit a list</button>
+                        </div>
+                        <div className="w-1/2 px-3 pb-3">
+                            <button className="btn w-full">
+                                View my shared cards
+                            </button>
+                        </div>
                     </div>
                     {searchResults.length > 0 && (
                         <div className="w-full px-3 pb-3">

--- a/resources/js/Pages/Dashboard.tsx
+++ b/resources/js/Pages/Dashboard.tsx
@@ -1,3 +1,4 @@
+import ButtonShelf from '@/Components/ButtonShelf';
 import Modal from '@/Components/Modal';
 import MTGCard from '@/Components/MTGCard';
 import PageTitle from '@/Components/PageTitle';
@@ -8,8 +9,8 @@ import { useState } from 'react';
 import { CardDataType } from '../types/mtg';
 
 // TO DO: remove cards from props and replace with decks
-export default function Dashboard({ cards }: { cards: { data: any } }) {
-    console.log('cards from BE', cards);
+export default function Dashboard({ decks }: { decks: { data: any } }) {
+    console.log('decks from BE', decks);
     const [showModal, setShowModal] = useState(false);
     const [searchResults, setSearchResults] = useState<CardDataType[]>([]);
 
@@ -33,30 +34,24 @@ export default function Dashboard({ cards }: { cards: { data: any } }) {
                     autofocus={true}
                     parentSetter={handleSearchResults}
                 />
+                <ButtonShelf
+                    buttons={[
+                        {
+                            label: 'Import a list',
+                            action: () => setShowModal(true),
+                        },
+                        {
+                            label: 'Create a list',
+                            action: () => console.log('create a list'),
+                        },
+                        {
+                            label: 'Edit a list',
+                            action: () => console.log('edit a list'),
+                        },
+                        { label: 'View my shared cards', link: '/cards' },
+                    ]}
+                />
                 <div className="-mx-3 flex flex-wrap">
-                    <div className="button-shelf w-full px-3 pb-3">
-                        <div className="w-1/2 px-3 pb-3">
-                            <button
-                                className="btn w-full"
-                                onClick={() => setShowModal(true)}
-                            >
-                                Import a list
-                            </button>
-                        </div>
-                        <div className="w-1/2 px-3 pb-3">
-                            <button className="btn w-full">
-                                Create a list
-                            </button>
-                        </div>
-                        <div className="w-1/2 px-3 pb-3">
-                            <button className="btn w-full">Edit a list</button>
-                        </div>
-                        <div className="w-1/2 px-3 pb-3">
-                            <button className="btn w-full">
-                                View my shared cards
-                            </button>
-                        </div>
-                    </div>
                     {searchResults.length > 0 && (
                         <div className="w-full px-3 pb-3">
                             <h2 className="text-lg font-semibold leading-tight text-gray-800 dark:text-gray-200">

--- a/resources/js/utility.ts
+++ b/resources/js/utility.ts
@@ -2,11 +2,15 @@ import { CardDataType } from './types/mtg';
 
 // currently an any because this takes the raw card data from scryfall.
 export const parseCardData = (cardData: any[]): CardDataType[] | [] => {
-    // Filter out cards that are not paper i.e. Arena only
-    const cardDataOnlyPaper = cardData.filter((card) =>
-        card.games.includes('paper'),
+    // Filter out cards that are not paper i.e. Arena only && tokens && art series
+    const preFilteredCardData = cardData.filter(
+        (card) =>
+            card.games.includes('paper') &&
+            !card.layout.includes('token') &&
+            !card.layout.includes('art_series'),
     );
-    const output = cardDataOnlyPaper.map((card) => {
+
+    const output = preFilteredCardData.map((card) => {
         const isDoubleFaced = card.card_faces ? true : false;
 
         let parsedCardData;

--- a/resources/js/utility.ts
+++ b/resources/js/utility.ts
@@ -87,3 +87,11 @@ export const turnManaCostIntoArray = (manaCost: string): string[] => {
 
     return [];
 };
+
+export const debounce = (func: Function, wait: number) => {
+    let timeout: NodeJS.Timeout;
+    return (...args: any[]) => {
+        clearTimeout(timeout);
+        timeout = setTimeout(() => func(...args), wait);
+    };
+};

--- a/resources/js/utility.ts
+++ b/resources/js/utility.ts
@@ -3,6 +3,7 @@ import { CardDataType } from './types/mtg';
 // currently an any because this takes the raw card data from scryfall.
 export const parseCardData = (cardData: any[]): CardDataType[] | [] => {
     // Filter out cards that are not paper i.e. Arena only && tokens && art series
+    // note: this might not be necessary if the scryfall search query is more specific
     const preFilteredCardData = cardData.filter(
         (card) =>
             card.games.includes('paper') &&
@@ -92,7 +93,7 @@ export const turnManaCostIntoArray = (manaCost: string): string[] => {
     return [];
 };
 
-export const debounce = (func: Function, wait: number) => {
+export const debounce = (func: (...args: any[]) => void, wait: number) => {
     let timeout: NodeJS.Timeout;
     return (...args: any[]) => {
         clearTimeout(timeout);


### PR DESCRIPTION
Fixes #40

- added button shelf component 
- buttons collapse to dual column on mobile
- button component takes likes and custom actions
- shelf sticks to top on scroll
- included additional filtering for scryfall query for art_series and tokens
- TO DO : 
- additional styling
- make navbar sticky as well

![Screenshot 2025-02-11 at 2 52 52 PM](https://github.com/user-attachments/assets/2b6b43b4-6055-481b-a00a-41d129676cbd)
![Screenshot 2025-02-11 at 2 53 02 PM](https://github.com/user-attachments/assets/9d200f25-02b9-4a27-91b8-0fe977a61fc0)
![Screenshot 2025-02-11 at 2 53 21 PM](https://github.com/user-attachments/assets/759e68ff-64d0-471a-82e6-315622a870f3)
![Screenshot 2025-02-11 at 3 11 54 PM](https://github.com/user-attachments/assets/86303ca8-cacc-4229-becd-faa545490b00)

on scroll 
<img width="1433" alt="Screenshot 2025-02-11 at 9 55 22 PM" src="https://github.com/user-attachments/assets/6deb5b5f-9cc3-43b1-b5da-a16ebb79523e" />


