### PR TITLE
Added Color and Partner filtering messaging 

### DIFF
--- a/resources/js/Components/ColorDivider.tsx
+++ b/resources/js/Components/ColorDivider.tsx
@@ -1,0 +1,23 @@
+import { mtgColors } from '@/constants';
+import { mtgColorStrings } from '@/types/mtg';
+
+export const ColorDivider = ({
+    colorIdentity,
+}: {
+    colorIdentity: mtgColorStrings[];
+}) => {
+    return (
+        <div className="color-divider flex h-[3px] w-full">
+            {colorIdentity?.map((color: mtgColorStrings) => (
+                <div
+                    key={`deck-color-${color}`}
+                    style={{
+                        backgroundColor:
+                            mtgColors.hex[color as keyof typeof mtgColors.hex],
+                    }}
+                    className="h-full w-full"
+                ></div>
+            ))}
+        </div>
+    );
+};

--- a/resources/js/Components/DeckTileDeckFace.tsx
+++ b/resources/js/Components/DeckTileDeckFace.tsx
@@ -1,4 +1,4 @@
-import { mtgColors } from '@/constants';
+import { ColorDivider } from '@/Components/ColorDivider';
 import { CardDataType, Deck } from '@/types/mtg';
 import { Dispatch, SetStateAction } from 'react';
 import { MdDeleteForever } from 'react-icons/md';
@@ -95,20 +95,7 @@ const DeckTileDeckFace = ({
                 className="deck-tile-body z-1 absolute bottom-0 left-0 flex h-auto w-full flex-wrap items-center justify-center rounded-b-md bg-zinc-900 p-0 pb-2 text-white shadow-md transition-transform duration-200 ease-in-out group-hover/deck-tile:bg-zinc-900/80"
                 onClick={() => activeSetter && activeSetter(deck)}
             >
-                <div className="color-divider flex h-[3px] w-full">
-                    {deck.color_identity?.map((color: string) => (
-                        <div
-                            key={`deck-color-${color}`}
-                            style={{
-                                backgroundColor:
-                                    mtgColors.hex[
-                                        color as keyof typeof mtgColors.hex
-                                    ],
-                            }}
-                            className="h-full w-full"
-                        ></div>
-                    ))}
-                </div>
+                <ColorDivider colorIdentity={deck.color_identity || []} />
                 <div className="w-full pt-1 text-center">
                     <h4 className="deck-tile-title hyphen-manual w-full text-wrap px-2 text-center font-bold">
                         {title.length > maxTitleLength

--- a/resources/js/Components/Searchbar.tsx
+++ b/resources/js/Components/Searchbar.tsx
@@ -3,6 +3,7 @@ import {
     scryfallNamedSearch,
     scryfallSearch,
 } from '@/api/Scryfall';
+import { ColorDivider } from '@/Components/ColorDivider';
 import { CardDataType, mtgColorStrings } from '@/types/mtg';
 import { debounce, useOutsideAlerter } from '@/utilities/general';
 import { prepCardDataForRender } from '@/utilities/prepCardData';
@@ -334,8 +335,23 @@ const Searchbar = ({
                     className="autocomplete-results-list z-99 relative w-auto rounded-b-lg bg-zinc-800"
                     tabIndex={0}
                 >
-                    <div className="sticky top-0 z-10 h-1 py-2 shadow-[inset_0_4px_6px_rgba(0,0,0,0.5)]"></div>
-                    {loading && <li>Loading results...</li>}
+                    <div className="sticky top-0 z-10 mb-2 shadow-[0_0_10px_0_rgba(0,0,0,1)]">
+                        <ColorDivider colorIdentity={colors || []} />
+                    </div>
+                    {!error && !loading && partnerSearch && (
+                        <li className="text-center text-xs font-semibold text-zinc-500">
+                            <span>filtering for partners:</span>
+                        </li>
+                    )}
+                    {!error && !loading && colors && colors.length > 0 && (
+                        <li className="text-center text-xs font-semibold text-zinc-500">
+                            <span>
+                                filtering by colors: {colors.join(', ')}
+                            </span>
+                        </li>
+                    )}
+                    {!error && loading && <li>Loading results...</li>}
+
                     {error && (
                         <li className="text-center text-red-500">
                             <span>{error}</span>


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of your changes -->
- added text to tell user what active filters are affecting the searchbar
- turned color divider into a component
- color divider embedded into searchbar to show filtered colors 

## Testing Performed or How to Test
<!-- Describe what testing you've done -->
 - [ ] create a deck and add two commanders - messaging should appear in search results
 - [ ] create a deck with a commander and begin adding cards - messaging should appear in card search results and color divider should display accurate color identity for commander


## Screenshots (if applicable)
<!-- Add screenshots here if there are UI changes -->
![Screenshot 2025-05-29 at 1 00 20 PM](https://github.com/user-attachments/assets/661af98d-7294-44d7-8fd5-e558f9bdf0c6)
![Screenshot 2025-05-29 at 1 00 37 PM](https://github.com/user-attachments/assets/f5896c24-99d5-47d8-96cf-047abc458920)

## Issues for later
- Searchbar component should be refactored to split autocomplete results into it's own component
